### PR TITLE
Use new Primitive names

### DIFF
--- a/lib/rubocop/cop/truffleruby/replace_with_primitive_nil.rb
+++ b/lib/rubocop/cop/truffleruby/replace_with_primitive_nil.rb
@@ -23,10 +23,10 @@ module RuboCop
       #   nil.equal?(object)
       #
       #   # bad
-      #   Primitive.object_equal(nil, object)
+      #   Primitive.equal?(nil, object)
       #
       #   # bad
-      #   Primitive.object_equal(object, nil)
+      #   Primitive.equal?(object, nil)
       #
       #   # good
       #   Primitive.nil?(object)
@@ -35,7 +35,7 @@ module RuboCop
         extend AutoCorrector
 
         MSG = 'Use `Primitive.nil?` instead of `Object#nil?` or `object == nil`'
-        RESTRICT_ON_SEND = %i[nil? == != equal? object_equal].freeze
+        RESTRICT_ON_SEND = %i[nil? == != equal?].freeze
 
         # @!method bad_method?(node)
         def_node_matcher :bad_method?, <<~PATTERN
@@ -45,8 +45,8 @@ module RuboCop
             (send $_ :!= nil)
             (send nil :equal? $_)
             (send $_ :equal? nil)
-            (send (const {nil? cbase} :Primitive) :object_equal $_ nil)
-            (send (const {nil? cbase} :Primitive) :object_equal nil $_)
+            (send (const {nil? cbase} :Primitive) :equal? $_ nil)
+            (send (const {nil? cbase} :Primitive) :equal? nil $_)
           }
         PATTERN
 

--- a/lib/rubocop/cop/truffleruby/replace_with_primitive_object_class.rb
+++ b/lib/rubocop/cop/truffleruby/replace_with_primitive_object_class.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module TruffleRuby
-      # Prefer Primitive method `object_class` to get a logical class of an object.
+      # Prefer `Primitive.class` to get a logical class of an object.
       #
       # @example
       #
@@ -11,12 +11,12 @@ module RuboCop
       #   object.class
       #
       #   # good
-      #   Primitive.object_class(object)
+      #   Primitive.class(object)
       #
       class ReplaceWithPrimitiveObjectClass < Base
         extend AutoCorrector
 
-        MSG = 'Use `Primitive.object_class` instead of `Object#class`'
+        MSG = 'Use `Primitive.class` instead of `Object#class`'
         RESTRICT_ON_SEND = %i[class].freeze
 
         # @!method bad_method?(node)
@@ -29,7 +29,7 @@ module RuboCop
           return unless receiver
 
           add_offense(node) do |corrector|
-            source_string = "Primitive.object_class(#{receiver.source})"
+            source_string = "Primitive.class(#{receiver.source})"
             corrector.replace(node.loc.expression, source_string)
           end
         end

--- a/lib/rubocop/cop/truffleruby/replace_with_primitive_object_equal.rb
+++ b/lib/rubocop/cop/truffleruby/replace_with_primitive_object_equal.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module TruffleRuby
-      # Prefer Primitive method `object_equal` to check whether two objects are
+      # Prefer Primitive method `equal?` to check whether two objects are
       # the same object.
       #
       # @example
@@ -12,12 +12,12 @@ module RuboCop
       #   foo.equal?(bar)
       #
       #   # good
-      #   Primitive.object_equal(foo, bar)
+      #   Primitive.equal?(foo, bar)
       #
       class ReplaceWithPrimitiveObjectEqual < Base
         extend AutoCorrector
 
-        MSG = 'Use `Primitive.object_equal` instead of `#equal?`'
+        MSG = 'Use `Primitive.equal?` instead of `#equal?`'
         RESTRICT_ON_SEND = %i[equal?].freeze
 
         # @!method bad_method?(node)
@@ -33,7 +33,7 @@ module RuboCop
             receiver, argument = captures.map { |n| n&.source }
             receiver ||= 'self'
 
-            source_string = "Primitive.object_equal(#{receiver}, #{argument})"
+            source_string = "Primitive.equal?(#{receiver}, #{argument})"
             corrector.replace(node.loc.expression, source_string)
           end
         end

--- a/lib/rubocop/cop/truffleruby/replace_with_primitive_object_kind_of.rb
+++ b/lib/rubocop/cop/truffleruby/replace_with_primitive_object_kind_of.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module TruffleRuby
-      # Prefer Primitive method `object_kind_of?` to check an object class for
+      # Prefer Primitive method `is_a?` to check an object class for
       # performance reasons.
       #
       # @safety
@@ -21,12 +21,12 @@ module RuboCop
       #   String === a
       #
       #   # good
-      #   Primitive.object_kind_of?(a, String)
+      #   Primitive.is_a?(a, String)
       #
       class ReplaceWithPrimitiveObjectKindOf < Base
         extend AutoCorrector
 
-        MSG = 'Use `Primitive.object_kind_of?` instead of `#kind_of?` or `#is_a?`'
+        MSG = 'Use `Primitive.is_a?` instead of `#kind_of?` or `#is_a?`'
         RESTRICT_ON_SEND = %i[is_a? kind_of? ===].freeze
 
         # @!method bad_method?(node)
@@ -58,7 +58,7 @@ module RuboCop
             constant = captures[1].source
           end
 
-          "Primitive.object_kind_of?(#{object}, #{constant})"
+          "Primitive.is_a?(#{object}, #{constant})"
         end
       end
     end

--- a/spec/rubocop/cop/truffleruby/replace_with_primitive_nil_spec.rb
+++ b/spec/rubocop/cop/truffleruby/replace_with_primitive_nil_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe RuboCop::Cop::TruffleRuby::ReplaceWithPrimitiveNil, :config do
 
   it 'registers an offense when using `Primitive.object_equal(nil, object)`' do
     expect_offense(<<~RUBY)
-      Primitive.object_equal(nil, object)
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveNil: Use `Primitive.nil?` instead of `Object#nil?` or `object == nil`
+      Primitive.equal?(nil, object)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveNil: Use `Primitive.nil?` instead of `Object#nil?` or `object == nil`
     RUBY
 
     expect_correction(<<~RUBY)
@@ -71,8 +71,8 @@ RSpec.describe RuboCop::Cop::TruffleRuby::ReplaceWithPrimitiveNil, :config do
 
   it 'registers an offense when using `Primitive.object_equal(object, nil)`' do
     expect_offense(<<~RUBY)
-      Primitive.object_equal(object, nil)
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveNil: Use `Primitive.nil?` instead of `Object#nil?` or `object == nil`
+      Primitive.equal?(object, nil)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveNil: Use `Primitive.nil?` instead of `Object#nil?` or `object == nil`
     RUBY
 
     expect_correction(<<~RUBY)

--- a/spec/rubocop/cop/truffleruby/replace_with_primitive_object_class_spec.rb
+++ b/spec/rubocop/cop/truffleruby/replace_with_primitive_object_class_spec.rb
@@ -6,17 +6,17 @@ RSpec.describe RuboCop::Cop::TruffleRuby::ReplaceWithPrimitiveObjectClass, :conf
   it 'registers an offense when using `#nil?`' do
     expect_offense(<<~RUBY)
       object.class
-      ^^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveObjectClass: Use `Primitive.object_class` instead of `Object#class`
+      ^^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveObjectClass: Use `Primitive.class` instead of `Object#class`
     RUBY
 
     expect_correction(<<~RUBY)
-      Primitive.object_class(object)
+      Primitive.class(object)
     RUBY
   end
 
-  it 'does not register an offense when using `Primitive.object_class`' do
+  it 'does not register an offense when using `Primitive.class`' do
     expect_no_offenses(<<~RUBY)
-      Primitive.object_class(object)
+      Primitive.class(object)
     RUBY
   end
 end

--- a/spec/rubocop/cop/truffleruby/replace_with_primitive_object_equal_spec.rb
+++ b/spec/rubocop/cop/truffleruby/replace_with_primitive_object_equal_spec.rb
@@ -6,28 +6,28 @@ RSpec.describe RuboCop::Cop::TruffleRuby::ReplaceWithPrimitiveObjectEqual, :conf
   it 'registers an offense when using `#equal?`' do
     expect_offense(<<~RUBY)
       foo.equal?(bar)
-      ^^^^^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveObjectEqual: Use `Primitive.object_equal` instead of `#equal?`
+      ^^^^^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveObjectEqual: Use `Primitive.equal?` instead of `#equal?`
     RUBY
 
     expect_correction(<<~RUBY)
-      Primitive.object_equal(foo, bar)
+      Primitive.equal?(foo, bar)
     RUBY
   end
 
   it 'registers an offense when using `#equal?` without explicit receiver' do
     expect_offense(<<~RUBY)
       equal?(bar)
-      ^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveObjectEqual: Use `Primitive.object_equal` instead of `#equal?`
+      ^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveObjectEqual: Use `Primitive.equal?` instead of `#equal?`
     RUBY
 
     expect_correction(<<~RUBY)
-      Primitive.object_equal(self, bar)
+      Primitive.equal?(self, bar)
     RUBY
   end
 
-  it 'does not register an offense when using `Primitive.object_equal`' do
+  it 'does not register an offense when using `Primitive.equal?`' do
     expect_no_offenses(<<~RUBY)
-      Primitive.object_equal(foo, bar)
+      Primitive.equal?(foo, bar)
     RUBY
   end
 

--- a/spec/rubocop/cop/truffleruby/replace_with_primitive_object_kind_of_spec.rb
+++ b/spec/rubocop/cop/truffleruby/replace_with_primitive_object_kind_of_spec.rb
@@ -6,66 +6,66 @@ RSpec.describe RuboCop::Cop::TruffleRuby::ReplaceWithPrimitiveObjectKindOf, :con
   it 'registers an offense when using `#kind_of?`' do
     expect_offense(<<~RUBY)
       a.kind_of?(String)
-      ^^^^^^^^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveObjectKindOf: Use `Primitive.object_kind_of?` instead of `#kind_of?` or `#is_a?`
+      ^^^^^^^^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveObjectKindOf: Use `Primitive.is_a?` instead of `#kind_of?` or `#is_a?`
     RUBY
 
     expect_correction(<<~RUBY)
-      Primitive.object_kind_of?(a, String)
+      Primitive.is_a?(a, String)
     RUBY
   end
 
   it 'registers an offense when using `#is_a?`' do
     expect_offense(<<~RUBY)
       a.is_a?(String)
-      ^^^^^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveObjectKindOf: Use `Primitive.object_kind_of?` instead of `#kind_of?` or `#is_a?`
+      ^^^^^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveObjectKindOf: Use `Primitive.is_a?` instead of `#kind_of?` or `#is_a?`
     RUBY
 
     expect_correction(<<~RUBY)
-      Primitive.object_kind_of?(a, String)
+      Primitive.is_a?(a, String)
     RUBY
   end
 
   it 'registers an offense when using `Module#===`' do
     expect_offense(<<~RUBY)
       String === a
-      ^^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveObjectKindOf: Use `Primitive.object_kind_of?` instead of `#kind_of?` or `#is_a?`
+      ^^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveObjectKindOf: Use `Primitive.is_a?` instead of `#kind_of?` or `#is_a?`
     RUBY
 
     expect_correction(<<~RUBY)
-      Primitive.object_kind_of?(a, String)
+      Primitive.is_a?(a, String)
     RUBY
   end
 
   it 'registers an offense when using `Module#===` and expression' do
     expect_offense(<<~RUBY)
       String === (a || b)
-      ^^^^^^^^^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveObjectKindOf: Use `Primitive.object_kind_of?` instead of `#kind_of?` or `#is_a?`
+      ^^^^^^^^^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveObjectKindOf: Use `Primitive.is_a?` instead of `#kind_of?` or `#is_a?`
     RUBY
 
     expect_correction(<<~RUBY)
-      Primitive.object_kind_of?((a || b), String)
+      Primitive.is_a?((a || b), String)
     RUBY
   end
 
   it 'registers an offense when there is no explicit receiver of `#kind_of?`' do
     expect_offense(<<~RUBY)
       kind_of?(String)
-      ^^^^^^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveObjectKindOf: Use `Primitive.object_kind_of?` instead of `#kind_of?` or `#is_a?`
+      ^^^^^^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveObjectKindOf: Use `Primitive.is_a?` instead of `#kind_of?` or `#is_a?`
     RUBY
 
     expect_correction(<<~RUBY)
-      Primitive.object_kind_of?(self, String)
+      Primitive.is_a?(self, String)
     RUBY
   end
 
   it 'registers an offense when there is no explicit receiver of `#is_a?`' do
     expect_offense(<<~RUBY)
       is_a?(String)
-      ^^^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveObjectKindOf: Use `Primitive.object_kind_of?` instead of `#kind_of?` or `#is_a?`
+      ^^^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveObjectKindOf: Use `Primitive.is_a?` instead of `#kind_of?` or `#is_a?`
     RUBY
 
     expect_correction(<<~RUBY)
-      Primitive.object_kind_of?(self, String)
+      Primitive.is_a?(self, String)
     RUBY
   end
 


### PR DESCRIPTION
Some Primitives were renamed in https://github.com/oracle/truffleruby/pull/3004:
- Primitive.object_equal to Primitive.equal?
- Primitive.object_kind_of to Primitive.is_a?
- Primitive.object_class to Primitive.class

Adjust the cops and tests to use these new names.
