### PR TITLE
Handle Primitive.equal? in ReplaceWithPrimitiveTrueAndFalsePredicates cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,9 @@ Naming/FileName:
 Style/Documentation:
   Enabled: false
 
+Style/GuardClause:
+  Enabled: false
+
 Metrics/BlockLength:
   Exclude:
     - spec/**/*.rb

--- a/lib/rubocop/cop/truffleruby/replace_with_primitive_true_and_false_predicates.rb
+++ b/lib/rubocop/cop/truffleruby/replace_with_primitive_true_and_false_predicates.rb
@@ -16,6 +16,9 @@ module RuboCop
       #   foo.equal?(true)
       #   foo.equal?(false)
       #
+      #   # bad
+      #   Primitive.equal?(foo, true)
+      #
       #   # good
       #   Primitive.true?(foo)
       #   Primitive.false?(foo)
@@ -27,29 +30,57 @@ module RuboCop
 
         RESTRICT_ON_SEND = %i[== != equal?].freeze
 
-        # @!method bad_method?(node)
-        def_node_matcher :bad_method?, <<~PATTERN
+        # @!method bad_core_method?(node)
+        def_node_matcher :bad_core_method?, <<~PATTERN
           (send $_ ${ :== :!= :equal? } ${ true false })
         PATTERN
 
-        def on_send(node)
-          captures = bad_method?(node)
-          return unless captures
+        # @!method bad_primitive_method?(node)
+        def_node_matcher :bad_primitive_method?, <<~PATTERN
+          (send
+            (const {nil? cbase} :Primitive)
+            :equal?
+            {
+              $_ ${ true false }
+              |
+              ${ true false } $_
+            }
+          )
+        PATTERN
 
-          add_offense(node) do |corrector|
-            source_string = build_source_string_to_replace_with(*captures)
-            corrector.replace(node.loc.expression, source_string)
-          end
+        def on_send(node)
+          on_bad_core_method(node) or on_bad_primitive_method(node)
         end
 
         private
 
-        def build_source_string_to_replace_with(receiver, method, argument)
-          receiver_source = receiver&.source || 'self'
-          optional_negation = method == :!= ? '!' : ''
-          primitive_name = argument.source == 'true' ? :true? : :false?
+        def on_bad_core_method(node)
+          captures = bad_core_method?(node)
+          return unless captures
 
-          "#{optional_negation}Primitive.#{primitive_name}(#{receiver_source})"
+          add_offense(node) do |corrector|
+            receiver, method, true_or_false = captures
+
+            receiver_source = receiver&.source || 'self'
+            optional_negation = method == :!= ? '!' : ''
+            primitive_name = true_or_false.true_type? ? :true? : :false?
+
+            source_string = "#{optional_negation}Primitive.#{primitive_name}(#{receiver_source})"
+            corrector.replace(node.loc.expression, source_string)
+          end
+        end
+
+        def on_bad_primitive_method(node)
+          captures = bad_primitive_method?(node)
+          return unless captures
+
+          add_offense(node) do |corrector|
+            true_or_false, object = captures[0].boolean_type? ? captures : captures.reverse
+            primitive_name = true_or_false.true_type? ? :true? : :false?
+
+            source_string = "Primitive.#{primitive_name}(#{object.source})"
+            corrector.replace(node.loc.expression, source_string)
+          end
         end
       end
     end

--- a/spec/rubocop/cop/truffleruby/replace_with_primitive_true_and_false_predicates_spec.rb
+++ b/spec/rubocop/cop/truffleruby/replace_with_primitive_true_and_false_predicates_spec.rb
@@ -113,6 +113,50 @@ RSpec.describe RuboCop::Cop::TruffleRuby::ReplaceWithPrimitiveTrueAndFalsePredic
     RUBY
   end
 
+  it 'registers an offense when using `Primitive.equal?` with true (at the first position)' do
+    expect_offense(<<~RUBY)
+      Primitive.equal?(true, foo)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveTrueAndFalsePredicates: Use `Primitive.true?` and `Primitive.false?` instead of `==` or `#equal?`
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Primitive.true?(foo)
+    RUBY
+  end
+
+  it 'registers an offense when using `Primitive.equal?` with true (at the last position)' do
+    expect_offense(<<~RUBY)
+      Primitive.equal?(foo, true)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveTrueAndFalsePredicates: Use `Primitive.true?` and `Primitive.false?` instead of `==` or `#equal?`
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Primitive.true?(foo)
+    RUBY
+  end
+
+  it 'registers an offense when using `Primitive.equal?` with false (at the first position)' do
+    expect_offense(<<~RUBY)
+      Primitive.equal?(false, foo)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveTrueAndFalsePredicates: Use `Primitive.true?` and `Primitive.false?` instead of `==` or `#equal?`
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Primitive.false?(foo)
+    RUBY
+  end
+
+  it 'registers an offense when using `Primitive.equal?` with false (at the last position)' do
+    expect_offense(<<~RUBY)
+      Primitive.equal?(foo, false)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TruffleRuby/ReplaceWithPrimitiveTrueAndFalsePredicates: Use `Primitive.true?` and `Primitive.false?` instead of `==` or `#equal?`
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Primitive.false?(foo)
+    RUBY
+  end
+
   it 'does not register an offense when using `Primitive.true?(foo)`' do
     expect_no_offenses(<<~RUBY)
       Primitive.true?(foo)
@@ -122,6 +166,12 @@ RSpec.describe RuboCop::Cop::TruffleRuby::ReplaceWithPrimitiveTrueAndFalsePredic
   it 'does not register an offense when using `Primitive.false?(foo)`' do
     expect_no_offenses(<<~RUBY)
       Primitive.false?(foo)
+    RUBY
+  end
+
+  it 'does not register an offense when using `Primitive.equal?` with arguments other than true/false' do
+    expect_no_offenses(<<~RUBY)
+      Primitive.equal?(foo, bar)
     RUBY
   end
 end


### PR DESCRIPTION
Handle also cases:

```ruby
Primitive.equal?(true, foo)
Primitive.equal?(false, foo)

Primitive.equal?(foo, true)
Primitive.equal?(foo, false)
```

And replace with `Primitive.true?(foo)` and `Primitive.false?(foo)`